### PR TITLE
add nanpa version management support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,30 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Publish crates
+name: Bump and publish crates
 
 on:
-  push:
-    tags:
-      - v*
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: "packages to bump"
+        type: string
+        required: true
 
 env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
 
 jobs:
+  bump:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nbsp/ilo@v1
+        with:
+          packages: ${{ github.event.inputs.packages }}
   publish:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Publish crates
         run: |
-          cd livekit-protocol && cargo publish --no-verify
-          cd ../webrtc-sys/build && cargo publish --no-verify
-          cd ../../webrtc-sys && cargo publish --no-verify
-          cd ../libwebrtc && cargo publish --no-verify
-          cd ../livekit-api && cargo publish --no-verify
-          cd ../livekit && cp ../README.md README.md && cargo publish --allow-dirty --no-verify
-          cd ../livekit-ffi && cargo publish --no-verify
+          git tag --points-at HEAD |
+          sed 's|^[^/]*@|@|' |
+          sed 's|^[^/]*/||' |
+          sed 's|@.*||' |
+          xargs -I _ sh -c 'cd _ && cargo publish --no-verify'

--- a/.nanparc
+++ b/.nanparc
@@ -1,0 +1,1 @@
+packages livekit livekit-ffi livekit-protocol livekit-runtime livekit-api libwebrtc webrtc-sys webrtc-sys/build

--- a/libwebrtc/.nanparc
+++ b/libwebrtc/.nanparc
@@ -1,0 +1,2 @@
+version 0.3.7
+language rust

--- a/livekit-api/.nanparc
+++ b/livekit-api/.nanparc
@@ -1,0 +1,2 @@
+version 0.4.0
+language rust

--- a/livekit-ffi/.nanparc
+++ b/livekit-ffi/.nanparc
@@ -1,0 +1,2 @@
+version 0.10.2
+language rust

--- a/livekit-protocol/.nanparc
+++ b/livekit-protocol/.nanparc
@@ -1,0 +1,2 @@
+version 0.3.5
+language rust

--- a/livekit-runtime/.nanparc
+++ b/livekit-runtime/.nanparc
@@ -1,0 +1,2 @@
+version 0.3.0
+language rust

--- a/livekit/.nanparc
+++ b/livekit/.nanparc
@@ -1,0 +1,2 @@
+version 0.6.0
+language rust

--- a/webrtc-sys/.nanparc
+++ b/webrtc-sys/.nanparc
@@ -1,0 +1,2 @@
+version 0.3.5
+language rust

--- a/webrtc-sys/build/.nanparc
+++ b/webrtc-sys/build/.nanparc
@@ -1,0 +1,2 @@
+version 0.3.5
+language rust


### PR DESCRIPTION
note that when updating a package and its dependent, you need to manually update the dependency version in the dependent.